### PR TITLE
Fix substitution in the application case of type inference

### DIFF
--- a/library/Example.hs
+++ b/library/Example.hs
@@ -112,7 +112,7 @@ inferType =
       (Abs x s ty) <- inferPi f
       ty' <- inferType v
       checkEq s ty'
-      substInto x ty' ty
+      substInto x v ty
 
 inferUniverse :: Monad m => Exp -> TcM m Int
 inferUniverse exp = do


### PR DESCRIPTION
When inferring the type of an application term, we should substitute the value of the argument, not the type. Otherwise you get results like this: (type of the identity function is correctly inferred, but not when the first argument, a type, is applied to it)

```
λ (a : Type 0) (t : a). t
  : Π (a : Type 0) (t : a). a

(λ (a : Type 0) (t : a). t) b
  = λ (t0 : b). t0
  : Π (t1 : Type 0). (Type 0)
```

[Bauer's blog post](http://math.andrej.com/2012/11/08/how-to-implement-dependent-type-theory-i/) has it right:
```ocaml
let rec infer_type ctx = function
  ...
  | App (e1, e2) ->
    let (x, s, t) = infer_pi ctx e1 in
    let te = infer_type ctx e2 in
      check_equal ctx s te ;
      subst [(x, e2)] t
```